### PR TITLE
Add build target for asc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 node_modules/
 npm-debug.*
+out/

--- a/bin/asc.tsconfig.json
+++ b/bin/asc.tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "outDir": "../out"
+  },
+  "files": [
+    "./asc.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typescript": "^2.4.0-dev.20170523"
   },
   "scripts": {
+    "build": "tsc -p ./bin/asc.tsconfig.json",
     "test": "node bin/asc --validate --text tests/test.ts"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
The build target uses tsc and asc.tsconfig.json directly
with stricter compilerOptions to identify possible issues
early.