### PR TITLE
implement new memcmp

### DIFF
--- a/lib/malloc/memcmp.c
+++ b/lib/malloc/memcmp.c
@@ -1,6 +1,47 @@
-int memcmp(const void *vl, const void *vr, size_t n)
-{
-	const unsigned char *l=vl, *r=vr;
-	for (; n && *l == *r; n--, l++, r++);
-	return n ? *l-*r : 0;
+
+// Adopted from yamiez.c
+int memcmp(const void *vl, const void *vr, size_t n) {
+  typedef unsigned char byte_type;
+  typedef unsigned long word_type;
+
+  const size_t word_size  = sizeof(word_type);
+  const size_t word_align = (word_size >= 8) ? word_size : 8;
+
+  const uintptr_t align_mask = word_align - 1;
+
+  const byte_type *buf1 = vl;
+  const byte_type *buf2 = vr;
+
+  const uintptr_t addr1 = (uintptr_t) vl;
+  const uintptr_t addr2 = (uintptr_t) vr;
+
+  if ((addr1 & align_mask) == (addr2 & align_mask)) {
+    const uintptr_t skip = word_align - (addr1 & align_mask);
+
+    for (uintptr_t i = 0; i < skip; ++i) {
+      if (*buf1++ != *buf2++)
+        goto end;
+      --n;
+    }
+
+    const word_type * wbuf1 = (const word_type *) buf1;
+    const word_type * wbuf2 = (const word_type *) buf2;
+
+    while (n >= word_size) {
+      if (*wbuf1++ != *wbuf2++)
+        goto end;
+      n -= word_size;
+    }
+
+    buf1 = (const byte_type *) wbuf1;
+    buf2 = (const byte_type *) wbuf2;
+  }
+
+  while (n--) {
+    if (*buf1++ != *buf2++)
+      goto end;
+  }
+
+end:
+  return n ? *buf1 - *buf2 : 0;
 }


### PR DESCRIPTION
Current implementation of ```memcmp``` looks exactly as emscripten version. I adopted but unfortunately not tested new approach:

![chart-perf](https://www.dropbox.com/s/ejmueqisr8gm5n9/memcpm-perf.png?raw=1)

**naive** is a emscripten-like
**yamiez** is new approach which very close to stdlib's

PS

Unfortunatly I can't build malloc.wasm on Mac OS
